### PR TITLE
Avoid infinite reconnection retries

### DIFF
--- a/logstash-output-redis.gemspec
+++ b/logstash-output-redis.gemspec
@@ -1,7 +1,7 @@
 Gem::Specification.new do |s|
 
   s.name            = 'logstash-output-redis'
-  s.version         = '1.0.0'
+  s.version         = '1.1.0'
   s.licenses        = ['Apache License (2.0)']
   s.summary         = "This output will send events to a Redis queue using RPUSH"
   s.description     = "This gem is a logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/plugin install gemname. This gem is not a stand-alone program"


### PR DESCRIPTION
Add a configuration option to set the number of times the output is going to try to reconnect in case of a failing connection. If reconnect_times if not defined then the former behaviour is expected,
going to retry connection forever.

Version 1.1.0 bump