### PR TITLE
Add codec support

### DIFF
--- a/lib/logstash/outputs/redis.rb
+++ b/lib/logstash/outputs/redis.rb
@@ -18,6 +18,8 @@ class LogStash::Outputs::Redis < LogStash::Outputs::Base
 
   config_name "redis"
 
+  default :codec, "json"
+
   # Name is used for logging in case there are multiple instances.
   # TODO: delete
   config :name, :validate => :string, :default => 'default',
@@ -137,46 +139,49 @@ class LogStash::Outputs::Redis < LogStash::Outputs::Base
     @host_idx = 0
 
     @congestion_check_times = Hash.new { |h,k| h[k] = Time.now.to_i - @congestion_interval }
+
+    @codec.on_event do |payload|
+      # How can I do this sort of thing with codecs?
+      #key = event.sprintf(@key)
+      key = @key
+
+      if @batch and @data_type == 'list' # Don't use batched method for pubsub.
+        # Stud::Buffer
+        buffer_receive(payload, key)
+        next
+      end
+
+      begin
+        @redis ||= connect
+        if @data_type == 'list'
+          congestion_check(key)
+          @redis.rpush(key, payload)
+        else
+          @redis.publish(key, payload)
+        end
+      rescue => e
+        @logger.warn("Failed to send event to Redis", :event => event,
+                     :identity => identity, :exception => e,
+                     :backtrace => e.backtrace)
+        sleep @reconnect_interval
+        @redis = nil
+        retry
+      end
+    end
   end # def register
 
   def receive(event)
     
 
-    if @batch and @data_type == 'list' # Don't use batched method for pubsub.
-      # Stud::Buffer
-      buffer_receive(event.to_json, event.sprintf(@key))
-      return
-    end
-
-    key = event.sprintf(@key)
     # TODO(sissel): We really should not drop an event, but historically
     # we have dropped events that fail to be converted to json.
     # TODO(sissel): Find a way to continue passing events through even
     # if they fail to convert properly.
     begin
-      payload = event.to_json
-    rescue Encoding::UndefinedConversionError, ArgumentError
-      puts "FAILUREENCODING"
-      @logger.error("Failed to convert event to JSON. Invalid UTF-8, maybe?",
-                    :event => event.inspect)
-      return
-    end
-
-    begin
-      @redis ||= connect
-      if @data_type == 'list'
-        congestion_check(key)
-        @redis.rpush(key, payload)
-      else
-        @redis.publish(key, payload)
-      end
-    rescue => e
-      @logger.warn("Failed to send event to Redis", :event => event,
-                   :identity => identity, :exception => e,
-                   :backtrace => e.backtrace)
-      sleep @reconnect_interval
-      @redis = nil
-      retry
+      @codec.encode(event)
+    rescue JSON::GeneratorError => e
+      @logger.warn("Trouble converting event to JSON", :exception => e,
+                   :event => event)
     end
   end # def receive
 

--- a/logstash-output-redis.gemspec
+++ b/logstash-output-redis.gemspec
@@ -26,5 +26,7 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency 'stud'
 
   s.add_development_dependency 'logstash-devutils'
+  s.add_development_dependency 'logstash-input-generator'
+  s.add_development_dependency 'logstash-codec-json'
 end
 

--- a/logstash-output-redis.gemspec
+++ b/logstash-output-redis.gemspec
@@ -28,5 +28,6 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'logstash-devutils'
   s.add_development_dependency 'logstash-input-generator'
   s.add_development_dependency 'logstash-codec-json'
+  s.add_development_dependency 'flores'
 end
 

--- a/spec/outputs/redis_spec.rb
+++ b/spec/outputs/redis_spec.rb
@@ -94,35 +94,5 @@ describe LogStash::Outputs::Redis, :redis => true do
       insist { redis.llen(key) } == 0
     end # agent
   end
-
-  describe "converts US-ASCII to utf-8 without failures" do
-    key = 10.times.collect { rand(10).to_s }.join("")
-
-    config <<-CONFIG
-      input {
-        generator {
-          charset => "US-ASCII"
-          message => "\xAD\u0000"
-          count => 1
-          type => "generator"
-        }
-      }
-      output {
-        redis {
-          host => "127.0.0.1"
-          key => "#{key}"
-          data_type => list
-        }
-      }
-    CONFIG
-
-    agent do
-      # Query redis directly and inspect the goodness.
-      redis = Redis.new(:host => "127.0.0.1")
-
-      # The list should contain no elements.
-      insist { redis.llen(key) } == 1
-    end # agent
-  end
 end
 

--- a/spec/outputs/redis_spec.rb
+++ b/spec/outputs/redis_spec.rb
@@ -55,11 +55,21 @@ describe LogStash::Outputs::Redis, :redis => true do
   end
 
   context "when batch_mode is true" do
-    include_examples "writing to redis list", { 
+    batch_events = Flores::Random.integer(1..1000)
+    batch_settings = { 
       "batch" => true,
-      "batch_timeout" => 5,
-      "timeout" => 5
+      "batch_events" => batch_events
     }
+
+    include_examples "writing to redis list", batch_settings do
+
+      # A canary to make sure we're actually enabling batch mode
+      # in this shared example.
+      it "should have batch mode enabled" do
+        expect(redis_config).to include("batch")
+        expect(redis_config["batch"]).to be_truthy
+      end
+    end
   end
 end
 


### PR DESCRIPTION


This PR picks up on work from #2 which adds codec support to this output. This PR further makes the following changes on top of that PR:

1) Uses newer `on_event` codec callback that passes the event so we can `sprintf` on the event - required since the `key` setting has historically supported sprintf.
2) Fixes the broken specs. This also included removing some unnecessary specs (that were testing unrelated integration with other plugins) as well as refactoring the specs to use shared_examples.
3) Small refactoring in the output itself.
4) Add necessary dev dependencies to the gemspec so the tests can run.

On my workstation, tests pass: `bundle exec rspec -t redis` under JRuby 1.7.23 (requires redis to be running):

```3 examples, 0 failures```