### PR TITLE
Expand hosts array documentation

### DIFF
--- a/lib/logstash/outputs/redis.rb
+++ b/lib/logstash/outputs/redis.rb
@@ -26,6 +26,8 @@ class LogStash::Outputs::Redis < LogStash::Outputs::Base
 
   # The hostname(s) of your Redis server(s). Ports may be specified on any
   # hostname, which will override the global port config.
+  # If the hosts list is an array, Logstash will pick one random host to connect to,
+  # if that host is disconnected it will then pick another.
   #
   # For example:
   # [source,ruby]


### PR DESCRIPTION
Clarified that the hosts directive can take an array, and how that works.

This was raised [here](https://discuss.elastic.co/t/question-on-logstash-output-to-redis/49374).