### PR TITLE
Redis output to store last values

### DIFF
--- a/lib/logstash/outputs/redis.rb
+++ b/lib/logstash/outputs/redis.rb
@@ -134,7 +134,7 @@ class LogStash::Outputs::Redis < LogStash::Outputs::Base
 
 
     if @batch
-      if ["list", "last_n_values"].include? @data_type
+      if not ["list", "last_n_values"].include? @data_type
         raise RuntimeError.new(
           "batch is not supported with data_type #{@data_type}"
         )

--- a/logstash-output-redis.gemspec
+++ b/logstash-output-redis.gemspec
@@ -1,7 +1,7 @@
 Gem::Specification.new do |s|
 
   s.name            = 'logstash-output-redis'
-  s.version         = '3.0.1'
+  s.version         = '2.1.0'
   s.licenses        = ['Apache License (2.0)']
   s.summary         = "This output will send events to a Redis queue using RPUSH"
   s.description     = "This gem is a Logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/logstash-plugin install gemname. This gem is not a stand-alone program"
@@ -20,7 +20,7 @@ Gem::Specification.new do |s|
   s.metadata = { "logstash_plugin" => "true", "logstash_group" => "output" }
 
   # Gem dependencies
-  s.add_runtime_dependency "logstash-core-plugin-api", "~> 2.0"
+  s.add_runtime_dependency "logstash-core-plugin-api", "~> 1.0"
 
   s.add_runtime_dependency 'redis'
   s.add_runtime_dependency 'stud'


### PR DESCRIPTION
Thanks for contributing to Logstash! If you haven't already signed our CLA, here's a handy link: https://www.elastic.co/contributor-agreement/

---

This PR augments the original `logstash-redis-output` plugin to store the last value(s) of each key in the event object.

The original redis output stores every event in a LIST, which just grows undefinitely unless trimmed by some other consumer. 

This PR adds 2 modes: 
- `last_n_values` will store the last n values of each key in the event object into a LIST (LPUSH and TRIM) with an EXPIRE value if defined. `stack_size` defines how many values are kept.
- `last_value` will store the last value of each key in the event object with SET with an EXPIRE value if defined.

In both cases the keys are stores under the top level key defined by `key`, into a tree structure matching the object.

Each write is done in a MULTI transaction so as to be sure to store all key/values at once.

Note: Since 5.alpha is alpha and not quite out yet, the PR is for Logstash 2.3.x, so the version number and dependencies are matching this version.

Let me know if this needs more attention.
