### PR TITLE
fix debug logging arguments to match proper signature

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
+## 3.0.3
+  - Fix logging method signature for #debug
 ## 3.0.2
   - Relax constraint on logstash-core-plugin-api to >= 1.60 <= 2.99
-
 ## 3.0.1
   - Republish all the gems under jruby.
 ## 3.0.0

--- a/lib/logstash/outputs/redis.rb
+++ b/lib/logstash/outputs/redis.rb
@@ -213,7 +213,7 @@ class LogStash::Outputs::Redis < LogStash::Outputs::Base
       :timeout => @timeout,
       :db => @db
     }
-    @logger.debug(params)
+    @logger.debug("connection params", params)
 
     if @password
       params[:password] = @password.value

--- a/logstash-output-redis.gemspec
+++ b/logstash-output-redis.gemspec
@@ -1,7 +1,7 @@
 Gem::Specification.new do |s|
 
   s.name            = 'logstash-output-redis'
-  s.version         = '3.0.2'
+  s.version         = '3.0.3'
   s.licenses        = ['Apache License (2.0)']
   s.summary         = "This output will send events to a Redis queue using RPUSH"
   s.description     = "This gem is a Logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/logstash-plugin install gemname. This gem is not a stand-alone program"


### PR DESCRIPTION
https://github.com/elastic/logstash/issues/6048 shows that RC1 is having trouble logging with the redis plugin