### PR TITLE
Mark deprecated `name` and `queue` configuration parameters as obsolete

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 4.0.0
+  - Mark deprecated `name` and `queue` configuration parameters as obsolete
+
 ## 3.0.3
   - Fix logging method signature for #debug
 ## 3.0.2

--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -119,8 +119,8 @@ Only supported for `list` Redis `data_type`.
   * Value can be any of: `list`, `channel`
   * There is no default value for this setting.
 
-Either list or channel.  If `redis_type` is list, then we will set
-RPUSH to key. If `redis_type` is channel, then we will PUBLISH to `key`.
+Either list or channel.  If `data_type` is list, then we will set
+RPUSH to key. If `data_type` is channel, then we will PUBLISH to `key`.
 
 [id="plugins-{type}s-{plugin}-db"]
 ===== `db` 
@@ -156,15 +156,6 @@ For example:
 The name of a Redis list or channel. Dynamic names are
 valid here, for example `logstash-%{type}`.
 
-[id="plugins-{type}s-{plugin}-name"]
-===== `name`  (DEPRECATED)
-
-  * DEPRECATED WARNING: This configuration item is deprecated and may not be available in future versions.
-  * Value type is <<string,string>>
-  * Default value is `"default"`
-
-Name is used for logging in case there are multiple instances.
-
 [id="plugins-{type}s-{plugin}-password"]
 ===== `password` 
 
@@ -180,16 +171,6 @@ Password to authenticate with.  There is no authentication by default.
   * Default value is `6379`
 
 The default port to connect on. Can be overridden on any hostname.
-
-[id="plugins-{type}s-{plugin}-queue"]
-===== `queue`  (DEPRECATED)
-
-  * DEPRECATED WARNING: This configuration item is deprecated and may not be available in future versions.
-  * Value type is <<string,string>>
-  * There is no default value for this setting.
-
-The name of the Redis queue (we'll use RPUSH on this). Dynamic names are
-valid here, for example `logstash-%{type}`
 
 [id="plugins-{type}s-{plugin}-reconnect_interval"]
 ===== `reconnect_interval` 

--- a/lib/logstash/outputs/redis.rb
+++ b/lib/logstash/outputs/redis.rb
@@ -21,8 +21,7 @@ class LogStash::Outputs::Redis < LogStash::Outputs::Base
   default :codec, "json"
 
   # Name is used for logging in case there are multiple instances.
-  config :name, :validate => :string, :default => 'default',
-    :deprecated => true
+  config :name, :validate => :string, :obsolete => "This option is obsolete"
 
   # The hostname(s) of your Redis server(s). Ports may be specified on any
   # hostname, which will override the global port config.
@@ -51,17 +50,15 @@ class LogStash::Outputs::Redis < LogStash::Outputs::Base
   # Password to authenticate with.  There is no authentication by default.
   config :password, :validate => :password
 
-  # The name of the Redis queue (we'll use RPUSH on this). Dynamic names are
-  # valid here, for example `logstash-%{type}`
-  config :queue, :validate => :string, :deprecated => true
+  config :queue, :validate => :string, :obsolete => "This option is obsolete. Use `key` and `data_type`."
 
   # The name of a Redis list or channel. Dynamic names are
   # valid here, for example `logstash-%{type}`.
-  config :key, :validate => :string, :required => false
+  config :key, :validate => :string, :required => true
 
   # Either list or channel.  If `redis_type` is list, then we will set
   # RPUSH to key. If `redis_type` is channel, then we will PUBLISH to `key`.
-  config :data_type, :validate => [ "list", "channel" ], :required => false
+  config :data_type, :validate => [ "list", "channel" ], :required => true
 
   # Set to true if you want Redis to batch up values and send 1 RPUSH command
   # instead of one command per value to push on the list.  Note that this only
@@ -97,25 +94,6 @@ class LogStash::Outputs::Redis < LogStash::Outputs::Base
 
   def register
     require 'redis'
-
-    # TODO remove after setting key and data_type to true
-    if @queue
-      if @key or @data_type
-        raise RuntimeError.new(
-          "Cannot specify queue parameter and key or data_type"
-        )
-      end
-      @key = @queue
-      @data_type = 'list'
-    end
-
-    if not @key or not @data_type
-      raise RuntimeError.new(
-        "Must define queue, or key and data_type parameters"
-      )
-    end
-    # end TODO
-
 
     if @batch
       if @data_type != "list"
@@ -224,7 +202,7 @@ class LogStash::Outputs::Redis < LogStash::Outputs::Base
 
   # A string used to identify a Redis instance in log messages
   def identity
-    @name || "redis://#{@password}@#{@current_host}:#{@current_port}/#{@db} #{@data_type}:#{@key}"
+    "redis://#{@password}@#{@current_host}:#{@current_port}/#{@db} #{@data_type}:#{@key}"
   end
 
   def send_to_redis(event, payload)

--- a/logstash-output-redis.gemspec
+++ b/logstash-output-redis.gemspec
@@ -1,7 +1,7 @@
 Gem::Specification.new do |s|
 
   s.name            = 'logstash-output-redis'
-  s.version         = '3.0.4'
+  s.version         = '4.0.0'
   s.licenses        = ['Apache License (2.0)']
   s.summary         = "This output will send events to a Redis queue using RPUSH"
   s.description     = "This gem is a Logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/logstash-plugin install gemname. This gem is not a stand-alone program"


### PR DESCRIPTION
Also, since queue is no longer available, we can mark `key` and
`data_type` as required and remove validations at `register` time.