### PR TITLE
Pin redis dep to 3.x.x since 4.x requires ruby 2+ syntax

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+## 4.0.2
+  - Tighten gem deps for the 'redis' gem
 ## 4.0.1
   - Fix some documentation issues
 

--- a/logstash-output-redis.gemspec
+++ b/logstash-output-redis.gemspec
@@ -1,7 +1,7 @@
 Gem::Specification.new do |s|
 
   s.name            = 'logstash-output-redis'
-  s.version         = '4.0.1'
+  s.version         = '4.0.2'
   s.licenses        = ['Apache License (2.0)']
   s.summary         = "This output will send events to a Redis queue using RPUSH"
   s.description     = "This gem is a Logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/logstash-plugin install gemname. This gem is not a stand-alone program"
@@ -22,7 +22,7 @@ Gem::Specification.new do |s|
   # Gem dependencies
   s.add_runtime_dependency "logstash-core-plugin-api", ">= 1.60", "<= 2.99"
 
-  s.add_runtime_dependency 'redis'
+  s.add_runtime_dependency 'redis', '~> 3'
   s.add_runtime_dependency 'stud'
 
   s.add_development_dependency 'logstash-devutils'


### PR DESCRIPTION
Output version of: https://github.com/logstash-plugins/logstash-input-redis/pull/59