### PR TITLE
Add ssl support

### DIFF
--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -172,8 +172,16 @@ Password to authenticate with.  There is no authentication by default.
 
 The default port to connect on. Can be overridden on any hostname.
 
+[id="plugins-{type}s-{plugin}-ssl"]
+===== `ssl`
+
+  * Value type is <<boolean,boolean>>
+  * Default value is `false`
+
+Enable SSL support.
+
 [id="plugins-{type}s-{plugin}-reconnect_interval"]
-===== `reconnect_interval` 
+===== `reconnect_interval`
 
   * Value type is <<number,number>>
   * Default value is `1`

--- a/lib/logstash/outputs/redis.rb
+++ b/lib/logstash/outputs/redis.rb
@@ -41,6 +41,9 @@ class LogStash::Outputs::Redis < LogStash::Outputs::Base
   # The default port to connect on. Can be overridden on any hostname.
   config :port, :validate => :number, :default => 6379
 
+  # SSL
+  config :ssl, :validate => :boolean, :default => false
+
   # The Redis database number.
   config :db, :validate => :number, :default => 0
 
@@ -189,7 +192,8 @@ class LogStash::Outputs::Redis < LogStash::Outputs::Base
       :host => @current_host,
       :port => @current_port,
       :timeout => @timeout,
-      :db => @db
+      :db => @db,
+      :ssl => @ssl
     }
     @logger.debug("connection params", params)
 


### PR DESCRIPTION
This PR is to extend ssl support to the logstash output plugin in the same way as it has been implemented in the logstash input plugin ([see PR](https://github.com/logstash-plugins/logstash-input-redis/pull/61)). 

**Use case:** We are running logstash on clients in aws and using an Elasticache redis cluster as our transport to Elasticsearch. If we configure our elasticache to use [in transit encryption](https://docs.aws.amazon.com/AmazonElastiCache/latest/UserGuide/in-transit-encryption.html), it can accept encrypted data from logstash. For our use case we're not concerned with certs.

Thanks for contributing to Logstash! If you haven't already signed our CLA, here's a handy link: https://www.elastic.co/contributor-agreement/
