### PR TITLE
Update index.asciidoc for correct required args

### DIFF
--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -44,10 +44,10 @@ This plugin supports the following configuration options plus the <<plugins-{typ
 | <<plugins-{type}s-{plugin}-batch_timeout>> |<<number,number>>|No
 | <<plugins-{type}s-{plugin}-congestion_interval>> |<<number,number>>|No
 | <<plugins-{type}s-{plugin}-congestion_threshold>> |<<number,number>>|No
-| <<plugins-{type}s-{plugin}-data_type>> |<<string,string>>, one of `["list", "channel"]`|No
+| <<plugins-{type}s-{plugin}-data_type>> |<<string,string>>, one of `["list", "channel"]`|Yes
 | <<plugins-{type}s-{plugin}-db>> |<<number,number>>|No
 | <<plugins-{type}s-{plugin}-host>> |<<array,array>>|No
-| <<plugins-{type}s-{plugin}-key>> |<<string,string>>|No
+| <<plugins-{type}s-{plugin}-key>> |<<string,string>>|Yes
 | <<plugins-{type}s-{plugin}-password>> |<<password,password>>|No
 | <<plugins-{type}s-{plugin}-port>> |<<number,number>>|No
 | <<plugins-{type}s-{plugin}-reconnect_interval>> |<<number,number>>|No


### PR DESCRIPTION
Documentation said `key` and `data_type` are not required, however there are no default values for those variables.  Therefore, they are required.

CLA signed.
