### PR TITLE
support redis cluster

### DIFF
--- a/lib/logstash/outputs/redis.rb
+++ b/lib/logstash/outputs/redis.rb
@@ -20,6 +20,20 @@ class LogStash::Outputs::Redis < LogStash::Outputs::Base
 
   default :codec, "json"
 
+
+
+  # Redis Cluster | Redis stand-alone config
+  # The value of true is cluster | The value of false is stand-alone
+  config :cluster, :validate => :boolean, :default => false
+
+  # Use this type for Redis Cluster
+  # The hostname(s) of your Redis server(s). Ports may be specified on any
+  #
+  # For example:
+  #     ["redis://password@127.0.0.1:7000", "redis://password@127.0.0.1:7001", "redis://password@127.0.0.1:7001"]
+  config :clusterHost, :validate => :array, :default => ["redis://password@127.0.0.1:7000"]
+
+  # Use this type for Redis stand-alone
   # The hostname(s) of your Redis server(s). Ports may be specified on any
   # hostname, which will override the global port config.
   # If the hosts list is an array, Logstash will pick one random host to connect to,
@@ -177,7 +191,7 @@ class LogStash::Outputs::Redis < LogStash::Outputs::Base
   private
   def connect
     if @cluster
-        Redis.new(cluster:@host)
+        Redis.new(cluster:@clusterHost)
     else
         @current_host, @current_port = @host[@host_idx].split(':')
         @host_idx = @host_idx + 1 >= @host.length ? 0 : @host_idx + 1

--- a/lib/logstash/outputs/redis.rb
+++ b/lib/logstash/outputs/redis.rb
@@ -176,27 +176,31 @@ class LogStash::Outputs::Redis < LogStash::Outputs::Base
 
   private
   def connect
-    @current_host, @current_port = @host[@host_idx].split(':')
-    @host_idx = @host_idx + 1 >= @host.length ? 0 : @host_idx + 1
+    if @cluster
+        Redis.new(cluster:@host)
+    else
+        @current_host, @current_port = @host[@host_idx].split(':')
+        @host_idx = @host_idx + 1 >= @host.length ? 0 : @host_idx + 1
 
-    if not @current_port
-      @current_port = @port
+        if not @current_port
+          @current_port = @port
+        end
+
+        params = {
+          :host => @current_host,
+          :port => @current_port,
+          :timeout => @timeout,
+          :db => @db,
+          :ssl => @ssl
+        }
+        @logger.debug("connection params", params)
+
+        if @password
+          params[:password] = @password.value
+        end
+
+        Redis.new(params)
     end
-
-    params = {
-      :host => @current_host,
-      :port => @current_port,
-      :timeout => @timeout,
-      :db => @db,
-      :ssl => @ssl
-    }
-    @logger.debug("connection params", params)
-
-    if @password
-      params[:password] = @password.value
-    end
-
-    Redis.new(params)
   end # def connect
 
   # A string used to identify a Redis instance in log messages


### PR DESCRIPTION
support redis cluster 
Test process:
logstash support redis cluster on version 6.6.0 come true：
**first:**
update redis-rb version to 4.1.3
package：/vendor/bundle/jruby/2.3.0/gems/redis-3.3.5
**second**
update /vendor/bundle/jruby/2.3.0/gems/logstash-output-redis-4.0.4/lib/logstash/outputs/redis.rb:
update connect function:  Submitted

**third**
config file update:

output {
    if [logtype]=="redis" {
        redis {
            codec => plain {
                format => "%{startDate} %{startHour} %{responseTime} %{apiCode} %{apiType} %{uid} %{success}"
            }
            data_type => "list"
            key => "test"
            clusterHost=> ["redis://@172.24.4.199:7000","redis://@172.24.4.199:7001","redis://@172.24.4.199:7002","redis://@172.24.4.198:7000","redis://@172.24.4.198:7001","redis://@172.24.4.198:7002"]
            batch => true
           cluster => true
        }
    }
}


